### PR TITLE
debian:source/options: use branch name as git-ref

### DIFF
--- a/debian/source/options
+++ b/debian/source/options
@@ -1,1 +1,1 @@
-git-ref=e704dbfc86c5d8934a5dd2b7cd42b4f366055bc9
+git-ref=debian/0.1


### PR DESCRIPTION
use branch name as git-ref instead of perticular commit,
after we restructured "libubootenv" package and prepared
"libubootenv-tools" package for fw_setenv/printenv binaries,
this change is required to get the working swupdate u-boot
env. saving functionality.

Fixes: https://mentorgraphics.atlassian.net/browse/SIEP-2364
Signed-off-by: Shrikant Bobade <Shrikant_Bobade@mentor.com>